### PR TITLE
Update to support Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,12 +129,12 @@ java {
     withSourcesJar()
     withJavadocJar()
 
-    sourceCompatibility = '11'
-    targetCompatibility = '11'
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
 
     // needed for XML-Doclet to work (since Doclet changed again with Java 13)
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(8))
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -210,8 +210,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <showWarnings>true</showWarnings>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <showDeprecation>true</showDeprecation>

--- a/src/main/java/net/sf/jsqlparser/expression/CastExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/CastExpression.java
@@ -16,6 +16,7 @@ import net.sf.jsqlparser.statement.select.Select;
 
 import java.util.ArrayList;
 import java.util.Set;
+import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -87,7 +88,7 @@ public class CastExpression extends ASTNodeAccessImpl implements Expression {
     }
 
     public static boolean isOf(ColDataType colDataType, DataType... types) {
-        return Set.of(types).contains(DataType.from(colDataType.getDataType()));
+        return Arrays.asList(types).contains(DataType.from(colDataType.getDataType()));
     }
 
     public static boolean isTime(ColDataType colDataType) {
@@ -237,7 +238,7 @@ public class CastExpression extends ASTNodeAccessImpl implements Expression {
     }
 
     public boolean isOf(DataType... types) {
-        return Set.of(types).contains(DataType.from(colDataType.getDataType()));
+        return Arrays.asList(types).contains(DataType.from(colDataType.getDataType()));
     }
 
     public boolean isTime() {

--- a/src/main/java/net/sf/jsqlparser/parser/ASTNodeAccessImpl.java
+++ b/src/main/java/net/sf/jsqlparser/parser/ASTNodeAccessImpl.java
@@ -11,6 +11,7 @@ package net.sf.jsqlparser.parser;
 
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.Arrays;
 
 public class ASTNodeAccessImpl implements ASTNodeAccess {
 
@@ -28,7 +29,7 @@ public class ASTNodeAccessImpl implements ASTNodeAccess {
 
     public StringBuilder appendTo(StringBuilder builder) {
         // don't add spaces around the following punctuation
-        final Set<String> punctuation = new TreeSet<>(Set.of(".", "[", "]"));
+        final Set<String> punctuation = new TreeSet<>(Arrays.asList(".", "[", "]"));
 
         SimpleNode simpleNode = getASTNode();
         if (simpleNode != null) {


### PR DESCRIPTION
## Summary
- downgrade source/target compatibility to Java 8
- adjust toolchain version
- remove usage of `Set.of` for Java 8 compatibility

## Testing
- `./gradlew build -x test` *(fails: Unable to tunnel through proxy)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68652c34d3ec8330bd357e469b586741